### PR TITLE
Deprecated data frame

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,8 @@ Version: 0.1.0
 Encoding: UTF-8
 Authors@R: c(
       person("Bob", "Rudis", role = c("aut", "cre"), email = "bob@rud.is"),
-      person("M", "Subbiah", role = c("aut"), comment = c("Original package author"))
+      person("M", "Subbiah", role = c("aut"), comment = c("Original package author")),
+	  person("Danilo", "Zocco", role = c("ctd"))
     )
 Maintainer: Bob Rudis <bob@rud.is>
 Description: Methods for obtaining simultaneous confidence intervals for multinomial 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,8 +4,7 @@ Version: 0.1.0
 Encoding: UTF-8
 Authors@R: c(
       person("Bob", "Rudis", role = c("aut", "cre"), email = "bob@rud.is"),
-      person("M", "Subbiah", role = c("aut"), comment = c("Original package author")),
-	  person("Danilo", "Zocco", role = c("ctd"))
+      person("M", "Subbiah", role = c("aut"), comment = c("Original package author"))
     )
 Maintainer: Bob Rudis <bob@rud.is>
 Description: Methods for obtaining simultaneous confidence intervals for multinomial 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,8 @@ Version: 0.1.0
 Encoding: UTF-8
 Authors@R: c(
       person("Bob", "Rudis", role = c("aut", "cre"), email = "bob@rud.is"),
-      person("M", "Subbiah", role = c("aut"), comment = c("Original package author"))
+      person("M", "Subbiah", role = c("aut"), comment = c("Original package author")),
+      person("Danilo", "Zocco", role = c("ctd"))
     )
 Maintainer: Bob Rudis <bob@rud.is>
 Description: Methods for obtaining simultaneous confidence intervals for multinomial 

--- a/R/aaa.r
+++ b/R/aaa.r
@@ -93,7 +93,7 @@ SG <- function(x, alpha) {
   diA <- ULA - LLA##FIND LENGTH OF CIs
   VOL <- round(prod(diA), 8)##PRODUCT OF LENGTH OF CIs
 
-  data_frame(
+  tibble(
     method = "sg",
     lower_limit = LL,
     upper_limit = UL,
@@ -131,7 +131,7 @@ BMDU <- function(x, d, seed=1492) {
       diff[j] <- u[j] - l[j]
     }
 
-    data_frame(
+    tibble(
       method = "bmdu",
       lower_limit = l,
       upper_limit = m,
@@ -141,7 +141,7 @@ BMDU <- function(x, d, seed=1492) {
 
   } else {
     warning('Size of the division should be less than the size of the input matrix')
-    data_frame(
+    tibble(
       method = "bmdu",
       lower_limit = l,
       upper_limit = m,

--- a/R/bmde.r
+++ b/R/bmde.r
@@ -35,7 +35,7 @@ scimp_bmde <- function(x, p, seed=1492) {
     dif[j] <- u[j] - l[j]
   }
 
-  data_frame(
+  tibble(
     method = "bmde",
     lower_limit = l,
     upper_limit = u,

--- a/R/fitz-scott.r
+++ b/R/fitz-scott.r
@@ -33,7 +33,7 @@ scimp_fs <- function(inpmat, alpha) {
   ci_length <- adj_ul - adj_ll
   volume <- round(prod(ci_length), 8)
 
-  data_frame(
+  tibble(
     method = "fs",
     lower_limit = fs_ll,
     upper_limit = fs_ul,

--- a/R/goodman.r
+++ b/R/goodman.r
@@ -33,7 +33,7 @@ scimp_goodman <- function(inpmat, alpha) {
   ci_length <- adj_ul - adj_ll
   volume <- round(prod(ci_length), 8)
 
-  data_frame(
+  tibble(
     method = "goodman",
     lower_limit = goodman_ll,
     upper_limit = goodman_ul,

--- a/R/qh.r
+++ b/R/qh.r
@@ -33,7 +33,7 @@ scimp_qh <- function(inpmat, alpha) {
   ci_length <- adj_ul - adj_ll
   volume <- round(prod(ci_length), 8)
 
-  data_frame(
+  tibble(
     method = "qh",
     lower_limit = qh_ll,
     upper_limit = qh_ul,

--- a/R/wald.r
+++ b/R/wald.r
@@ -35,7 +35,7 @@ scimp_wald <- function(inpmat, alpha) {
   ci_length <- adj_ul - adj_ll
   volume <- round(prod(ci_length), 8)
 
-  data_frame(
+  tibble(
     method = "wald",
     lower_limit = wald_ll,
     upper_limit = wald_ul,

--- a/R/waldcc.r
+++ b/R/waldcc.r
@@ -32,7 +32,7 @@ scimp_waldcc <- function(inpmat, alpha) {
   ci_length <- adj_ul - adj_ll
   volume <- round(prod(ci_length), 8)
 
-  data_frame(
+  tibble(
     method = "waldcc",
     lower_limit = waldcc_ll,
     upper_limit = waldcc_ul,

--- a/R/wilson.r
+++ b/R/wilson.r
@@ -33,7 +33,7 @@ scimp_wilson <- function(inpmat, alpha) {
   ci_length <- adj_ul - adj_ll
   volume <- round(prod(ci_length), 8)
 
-  data_frame(
+  tibble(
     method = "wilson",
     lower_limit = wilson_ll,
     upper_limit = wilson_ul,


### PR DESCRIPTION
While using ```scimple_ci```, I got the following:
```
Warning message:
`data_frame()` is deprecated as of tibble 1.1.0.
Please use `tibble()` instead.
```

I therefore updated every function using ```data_frame()``` to use ```tibble()``` instead.
I did some testing and the outputs are consistent.